### PR TITLE
Update exchange rate API and default currencies

### DIFF
--- a/source/common/money.js
+++ b/source/common/money.js
@@ -1,4 +1,4 @@
-fetch("https://api.exchangeratesapi.io/latest?base=USD").then(function(e){
+fetch("https://api.exchangerate.host/latest?base=USD").then(function(e){
     return e.json();
 }).then(function(e){
     console.debug("[Request] Exchange request successfully");

--- a/source/common/money.js
+++ b/source/common/money.js
@@ -1,4 +1,4 @@
-fetch("https://api.exchangerate.host/latest?base=USD").then(function(e){
+fetch("https://api.exchangerate.host/latest?base=USD&symbols=USD,CAD,AUD,GBP,EUR").then(function(e){
     return e.json();
 }).then(function(e){
     console.debug("[Request] Exchange request successfully");
@@ -10,7 +10,7 @@ fetch("https://api.exchangerate.host/latest?base=USD").then(function(e){
 });
 
 var base = "USD";
-var rates = {"CAD":1.3195727727,"HKD":7.7501059591,"ISK":137.49258286,"PHP":48.4589302365,"DKK":6.3063490718,"HUF":306.145630245,"CZK":22.6727134017,"GBP":0.7758752225,"RON":4.119691447,"SEK":8.8225820124,"IDR":14835.1869119268,"INR":73.6297363737,"BRL":5.2654912266,"RUB":75.1101975078,"HRK":6.3929812664,"JPY":104.5859116725,"THB":31.1952191235,"CHF":0.910570484,"EUR":0.8476731372,"MYR":4.1385097906,"BGN":1.6578791218,"TRY":7.547427312,"CNY":6.7696024413,"NOK":9.0902771891,"NZD":1.4862253115,"ZAR":16.3323726371,"USD":1.0,"MXN":21.0613715351,"SGD":1.3595829448,"AUD":1.3691616513,"ILS":3.4230736628,"KRW":1172.4675765025,"PLN":3.7788420785}
+var rates = {"AUD":1.376691,"CAD":1.264755,"EUR":0.879665,"GBP":0.739946,"USD":1}
 rates["USD"] = 1;
 
 function ready(apiRates){


### PR DESCRIPTION
- The API went to paid only, needing an API key so we switch to a new working API.
- Only use the currencies that Spigot accepts as payment.